### PR TITLE
Removed excess </span> tag

### DIFF
--- a/slider-entity-row.js
+++ b/slider-entity-row.js
@@ -52,7 +52,6 @@ class SliderEntityRow extends Polymer.Element {
                 ></ha-entity-toggle>
                 </span>
             </template>
-            </span>
           </div>
       </div>
     `;


### PR DESCRIPTION
As i'm trying to modify this element to my own liking, I found this </span> that seems to be without any opening "partner". Btw, what i'm trying to achieve is to have the inline slider moved to the right by removing the toggle, and allowing for longer entity names.