### PR TITLE
Add min, max, and step to Configuration

### DIFF
--- a/slider-entity-row.js
+++ b/slider-entity-row.js
@@ -29,10 +29,10 @@ class SliderEntityRow extends Polymer.Element {
           <div class="flex">
         <template is="dom-if" if="{{displaySlider}}">
             <ha-slider
-              min="0"
-              max="100"
+              min="[[min]]"
+              max="[[max]]"
               value="{{value}}"
-              step="5"
+              step="[[step]]"
               pin
               on-change="selectedValue"
               on-click="stopPropagation"
@@ -152,6 +152,10 @@ class SliderEntityRow extends Polymer.Element {
     this.displayToggle = config.toggle && domain === 'light';
     this.displayValue = !this.displayToggle;
     this.displaySlider = false;
+
+    this.min = config.min || 0;
+    this.max = config.max || 100;
+    this.step = config.step || 5;
   }
 
   statusString(stateObj) {


### PR DESCRIPTION
This adds the ability to set the min, max, and slider stepping.
Min is mostly useful for dimmers that go lower than what the light can output.
I haven't found a good use-case for max, but I figured adding it wouldn't hurt.

Example
```yaml
  - title: slider-entity-row
    cards:
    - type: entities
      title: Inside Lights
      entities:
        - entity: light.living_room
          type: custom:slider-entity-row
          toggle: true
          step: 1
          min: 6
          max: 95
```