### PR TITLE
Add support for fan and input_select

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 slider-entity-row
 =================
 
-Add a slider to adjust brightness of lights, volume of media players or position of covers in lovelace entity cards
+Add a slider to adjust brightness of lights, volume of media players, position of covers and speed of fans in lovelace entity cards
 
 ![slider-entity-row](https://user-images.githubusercontent.com/1299821/48869222-b6303200-eddc-11e8-8b8c-7b4a9601df7a.png)
 
@@ -86,3 +86,6 @@ Add a slider to adjust brightness of lights, volume of media players or position
 `step` - (default: 5) Step size of slider
 Note that slider values are in percent and will be rescaled e.g. for lights which require a brightness setting between 0 and 255.
 
+
+---
+Thanks to Gabe Cook (@gabe565) for help with fan support. 

--- a/slider-entity-row.js
+++ b/slider-entity-row.js
@@ -101,11 +101,9 @@ class SliderEntityRow extends Polymer.Element {
           if(stateObj.state === 'off') return l18n['state.default.off'];
           return `${this.controller.get(stateObj)} %`;
         },
-        config: () => ({
-          min: 0,
-          max: 100,
-          step: 5,
-        }),
+        min: () => 0,
+        max: () => 100,
+        step: () => 5,
       },
 
       media_player: {
@@ -124,11 +122,9 @@ class SliderEntityRow extends Polymer.Element {
           if (stateObj.attributes.is_volume_muted) return '-';
           return `${this.controller.get(stateObj)} %`;
         },
-        config: () => ({
-          min: 0,
-          max: 100,
-          step: 5,
-        }),
+        min: () => 0,
+        max: () => 100,
+        step: () => 5,
       },
 
       cover: {
@@ -155,17 +151,13 @@ class SliderEntityRow extends Polymer.Element {
           if (stateObj.state === 'closed') return l18n['state.cover.closed'];
           return `${this.controller.get(stateObj)} %`;
         },
-        config: () => ({
-          min: 0,
-          max: 100,
-          step: 5,
-        }),
+        min: () => 0,
+        max: () => 100,
+        step: () => 5,
       },
 
       fan: {
         set: (stateObj, value) => {
-          if (!this.numeric)
-            value = Math.round(value/100.0*stateObj.attributes.speed_list.length)
           --value;
           if (value in stateObj.attributes.speed_list)
             this._hass.callService('fan', 'turn_on', { entity_id: stateObj.entity_id, speed: stateObj.attributes.speed_list[value] });
@@ -174,10 +166,7 @@ class SliderEntityRow extends Polymer.Element {
         },
         get: (stateObj) => {
           if (stateObj.state !== 'on') return 0;
-          if (!this.numeric)
-            return Math.round((stateObj.attributes.speed_list.indexOf(stateObj.attributes.speed)+1)*100.0/stateObj.attributes.speed_list.length);
-          else
-            return stateObj.attributes.speed;
+          return stateObj.attributes.speed;
         },
         supported: {
           slider: (stateObj) => {
@@ -191,36 +180,17 @@ class SliderEntityRow extends Polymer.Element {
           if(stateObj.state === 'off') return l18n['state.default.off'];
           return stateObj.attributes.speed;
         },
-        config: (stateObj) => {
-          if (!stateObj.attributes.speed_list.some(isNaN)) {
-            this.numeric = true
-            return {
-              min: Number(Math.min(...stateObj.attributes.speed_list)-1),
-              max: Number(Math.max(...stateObj.attributes.speed_list)),
-              step: 1,
-            }
-          } else {
-            this.numeric = false
-            return {
-              min: 0,
-              max: 100,
-              step: Math.round(100/(stateObj.attributes.speed_list.length)),
-            }
-          };
-        },
+        min: (stateObj) => 0,
+        max: (stateObj) => stateObj.attributes.speed_list.length,
+        step: () => 1,
       },
 
       input_select: {
         set: (stateObj, value) => {
-          if (!this.numeric)
-            value = Math.round(value/100.0*(stateObj.attributes.options.length-1))
           if (value in stateObj.attributes.options)
             this._hass.callService('input_select', 'select_option', { entity_id: stateObj.entity_id, option: stateObj.attributes.options[value] });
         },
         get: (stateObj) => {
-          if (!this.numeric)
-            return Math.round(stateObj.attributes.options.indexOf(stateObj.state)*100.0/(stateObj.attributes.options.length-1));
-          else
             return stateObj.state
         },
         supported: {
@@ -230,26 +200,10 @@ class SliderEntityRow extends Polymer.Element {
           },
           toggle: () => false,
         },
-        string: (stateObj, l18n) => {
-          return stateObj.state;
-        },
-        config: (stateObj) => {
-          if (!stateObj.attributes.options.some(isNaN)) {
-            this.numeric = true
-            return {
-              min: Number(Math.min(...stateObj.attributes.options)),
-              max: Number(Math.max(...stateObj.attributes.options)),
-              step: 1,
-            }
-          } else {
-            this.numeric = false
-            return {
-              min: 0,
-              max: 100,
-              step: Math.round(100/(stateObj.attributes.options.length-1)),
-            }
-          };
-        },
+        string: (stateObj) => stateObj.state,
+        min: () => 0,
+        max: (stateObj) => stateObj.attributes.options.length-1,
+        step: () => 1,
       },
     };
 
@@ -273,10 +227,9 @@ class SliderEntityRow extends Polymer.Element {
     if(this._hass && this._config) {
       this.stateObj = this._config.entity in this._hass.states ? this._hass.states[this._config.entity] : null;
       if(this.stateObj) {
-        let controllerConfig = this.controller.config(this.stateObj);
-        this.min = this._config.min || controllerConfig.min;
-        this.max = this._config.max || controllerConfig.max;
-        this.step = this._config.step || controllerConfig.step;
+        this.min = this._config.min || this.controller.min(this.stateObj);
+        this.max = this._config.max || this.controller.max(this.stateObj);
+        this.step = this._config.step || this.controller.step(this.stateObj);
         this.value = this.controller.get(this.stateObj);
         this.displaySlider = this.controller.supported.slider(this.stateObj);
       }
@@ -295,10 +248,9 @@ class SliderEntityRow extends Polymer.Element {
     if(hass && this._config) {
       this.stateObj = this._config.entity in hass.states ? hass.states[this._config.entity] : null;
       if(this.stateObj) {
-        let controllerConfig = this.controller.config(this.stateObj);
-        this.min = this._config.min || controllerConfig.min;
-        this.max = this._config.max || controllerConfig.max;
-        this.step = this._config.step || controllerConfig.step;
+        this.min = this._config.min || this.controller.min(this.stateObj);
+        this.max = this._config.max || this.controller.max(this.stateObj);
+        this.step = this._config.step || this.controller.step(this.stateObj);
         this.value = this.controller.get(this.stateObj);
         this.displaySlider = this.controller.supported.slider(this.stateObj);
       }

--- a/slider-entity-row.js
+++ b/slider-entity-row.js
@@ -158,7 +158,7 @@ class SliderEntityRow extends Polymer.Element {
           else
             this._hass.callService('fan', 'turn_off', { entity_id: stateObj.entity_id });
         },
-        get: (stateObj) => (stateObj.state !== 'off')?stateObj.attributes.speed:0,
+        get: (stateObj) => (stateObj.state !== 'off')?stateObj.attributes.speed_list.indexOf(stateObj.attributes.speed)+1:0,
         supported: {
           slider: (stateObj) => !(stateObj.state === 'off' && this._config.hide_when_off) && stateObj.attributes.hasOwnProperty('speed'),
           toggle: () => true,
@@ -177,7 +177,7 @@ class SliderEntityRow extends Polymer.Element {
           if (value in stateObj.attributes.options)
             this._hass.callService('input_select', 'select_option', { entity_id: stateObj.entity_id, option: stateObj.attributes.options[value] });
         },
-        get: (stateObj) => stateObj.state,
+        get: (stateObj) => stateObj.attributes.options.indexOf(stateObj.state),
         supported: {
           slider: (stateObj) => stateObj.attributes.hasOwnProperty('options') && stateObj.attributes.options.length > 1,
           toggle: () => false,

--- a/slider-entity-row.js
+++ b/slider-entity-row.js
@@ -172,6 +172,28 @@ class SliderEntityRow extends Polymer.Element {
         },
         step: 0,
       },
+
+      input_select: {
+        set: (stateObj, value) => {
+          value = Math.round(value/100.0*(stateObj.attributes.options.length-1))
+          if (value in stateObj.attributes.options)
+            this._hass.callService('input_select', 'select_option', { entity_id: stateObj.entity_id, option: stateObj.attributes.options[value] });
+        },
+        get: (stateObj) => {
+          return Math.round(stateObj.attributes.options.indexOf(stateObj.state)*100.0/(stateObj.attributes.options.length-1));
+        },
+        supported: {
+          slider: (stateObj) => {
+            if('options' in stateObj.attributes && stateObj.attributes.options.length > 1) return true;
+            return false;
+          },
+          toggle: () => false,
+        },
+        string: (stateObj, l18n) => {
+          return stateObj.state;
+        },
+        step: 0,
+      },
     };
 
 

--- a/slider-entity-row.js
+++ b/slider-entity-row.js
@@ -84,9 +84,7 @@ class SliderEntityRow extends Polymer.Element {
           else
             this._hass.callService('light', 'turn_off', { entity_id: stateObj.entity_id });
         },
-        get: (stateObj) => {
-          return (stateObj.state === 'on')?Math.ceil(stateObj.attributes.brightness*100.0/255):0;
-        },
+        get: (stateObj) => (stateObj.state === 'on')?Math.ceil(stateObj.attributes.brightness*100.0/255):0,
         supported: {
           slider: (stateObj) => {
             if(stateObj.state === 'off' && this._config.hide_when_off) return false;
@@ -111,9 +109,7 @@ class SliderEntityRow extends Polymer.Element {
           value = value/100.0;
           this._hass.callService('media_player', 'volume_set', { entity_id: stateObj.entity_id, volume_level: value });
         },
-        get: (stateObj) => {
-          return (stateObj.attributes.is_volume_muted)?0:Math.ceil(stateObj.attributes.volume_level*100.0);
-        },
+        get: (stateObj) => (stateObj.attributes.is_volume_muted)?0:Math.ceil(stateObj.attributes.volume_level*100.0),
         supported: {
           slider: () => true,
           toggle: () => false,
@@ -134,13 +130,11 @@ class SliderEntityRow extends Polymer.Element {
           else
             this._hass.callService('cover', 'close_cover', { entity_id: stateObj.entity_id });
         },
-        get: (stateObj) => {
-          return (stateObj.state === 'open')?Math.ceil(stateObj.attributes.current_position):0;
-        },
+        get: (stateObj) => (stateObj.state === 'open')?Math.ceil(stateObj.attributes.current_position):0,
         supported: {
           slider: (stateObj) => {
-            if('current_position' in stateObj.attributes) return true;
-            if(('supported_features' in stateObj.attributes) &&
+            if(stateObj.attributes.hasOwnProperty('current_position')) return true;
+            if((stateObj.attributes.hasOwnProperty('supported_features')) &&
               (stateObj.attributes.supported_features & 4)) return true;
             return false;
           },
@@ -164,16 +158,9 @@ class SliderEntityRow extends Polymer.Element {
           else
             this._hass.callService('fan', 'turn_off', { entity_id: stateObj.entity_id });
         },
-        get: (stateObj) => {
-          if (stateObj.state !== 'on') return 0;
-          return stateObj.attributes.speed;
-        },
+        get: (stateObj) => (stateObj.state !== 'off')?stateObj.attributes.speed:0,
         supported: {
-          slider: (stateObj) => {
-            if(stateObj.state === 'off' && this._config.hide_when_off) return false;
-            if('speed' in stateObj.attributes) return true;
-            return false;
-          },
+          slider: (stateObj) => !(stateObj.state === 'off' && this._config.hide_when_off) && stateObj.attributes.hasOwnProperty('speed'),
           toggle: () => true,
         },
         string: (stateObj, l18n) => {
@@ -190,14 +177,9 @@ class SliderEntityRow extends Polymer.Element {
           if (value in stateObj.attributes.options)
             this._hass.callService('input_select', 'select_option', { entity_id: stateObj.entity_id, option: stateObj.attributes.options[value] });
         },
-        get: (stateObj) => {
-            return stateObj.state
-        },
+        get: (stateObj) => stateObj.state,
         supported: {
-          slider: (stateObj) => {
-            if('options' in stateObj.attributes && stateObj.attributes.options.length > 1) return true;
-            return false;
-          },
+          slider: (stateObj) => stateObj.attributes.hasOwnProperty('options') && stateObj.attributes.options.length > 1,
           toggle: () => false,
         },
         string: (stateObj) => stateObj.state,

--- a/slider-entity-row.js
+++ b/slider-entity-row.js
@@ -164,7 +164,7 @@ class SliderEntityRow extends Polymer.Element {
 
       fan: {
         set: (stateObj, value) => {
-          if (stateObj.attributes.speed_list.some(isNaN))
+          if (!this.numeric)
             value = Math.round(value/100.0*stateObj.attributes.speed_list.length)
           --value;
           if (value in stateObj.attributes.speed_list)
@@ -174,7 +174,7 @@ class SliderEntityRow extends Polymer.Element {
         },
         get: (stateObj) => {
           if (stateObj.state !== 'on') return 0;
-          if (stateObj.attributes.speed_list.some(isNaN))
+          if (!this.numeric)
             return Math.round((stateObj.attributes.speed_list.indexOf(stateObj.attributes.speed)+1)*100.0/stateObj.attributes.speed_list.length);
           else
             return stateObj.attributes.speed;
@@ -192,30 +192,33 @@ class SliderEntityRow extends Polymer.Element {
           return stateObj.attributes.speed;
         },
         config: (stateObj) => {
-          if (!stateObj.attributes.speed_list.some(isNaN))
+          if (!stateObj.attributes.speed_list.some(isNaN)) {
+            this.numeric = true
             return {
               min: Number(Math.min(...stateObj.attributes.speed_list)-1),
               max: Number(Math.max(...stateObj.attributes.speed_list)),
               step: 1,
             }
-          else
+          } else {
+            this.numeric = false
             return {
               min: 0,
               max: 100,
               step: Math.round(100/(stateObj.attributes.speed_list.length)),
             }
+          };
         },
       },
 
       input_select: {
         set: (stateObj, value) => {
-          if (stateObj.attributes.options.some(isNaN))
+          if (!this.numeric)
             value = Math.round(value/100.0*(stateObj.attributes.options.length-1))
           if (value in stateObj.attributes.options)
             this._hass.callService('input_select', 'select_option', { entity_id: stateObj.entity_id, option: stateObj.attributes.options[value] });
         },
         get: (stateObj) => {
-          if (stateObj.attributes.options.some(isNaN))
+          if (!this.numeric)
             return Math.round(stateObj.attributes.options.indexOf(stateObj.state)*100.0/(stateObj.attributes.options.length-1));
           else
             return stateObj.state
@@ -231,18 +234,21 @@ class SliderEntityRow extends Polymer.Element {
           return stateObj.state;
         },
         config: (stateObj) => {
-          if (!stateObj.attributes.options.some(isNaN))
+          if (!stateObj.attributes.options.some(isNaN)) {
+            this.numeric = true
             return {
               min: Number(Math.min(...stateObj.attributes.options)),
               max: Number(Math.max(...stateObj.attributes.options)),
               step: 1,
             }
-          else
+          } else {
+            this.numeric = false
             return {
               min: 0,
               max: 100,
               step: Math.round(100/(stateObj.attributes.options.length-1)),
             }
+          };
         },
       },
     };

--- a/slider-entity-row.js
+++ b/slider-entity-row.js
@@ -156,7 +156,7 @@ class SliderEntityRow extends Polymer.Element {
             this._hass.callService('fan', 'turn_off', { entity_id: stateObj.entity_id });
         },
         get: (stateObj) => {
-          return (stateObj.state === 'on')?Math.round(stateObj.attributes.speed*100.0/stateObj.attributes.speed_list.length):0;
+          return (stateObj.state === 'on')?Math.round((stateObj.attributes.speed_list.indexOf(stateObj.attributes.speed)+1)*100.0/stateObj.attributes.speed_list.length):0;
         },
         supported: {
           slider: (stateObj) => {
@@ -168,7 +168,7 @@ class SliderEntityRow extends Polymer.Element {
         },
         string: (stateObj, l18n) => {
           if(stateObj.state === 'off') return l18n['state.default.off'];
-          return this.controller.get(stateObj);
+          return stateObj.attributes.speed;
         },
         step: 0,
       },


### PR DESCRIPTION
This adds support for `fan` and `input_select` domains.

Slider is based on the order of options entries. It supports lists of options (or fan speeds) whether they are numeric or not.

Both are working smoothly for me, but could probably use some more testing before merging in.