### PR TITLE
Support climate domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This works for:
 
 - `light` - set brightness
 - `media_player` - set volume
+- `climate` - set temperature
 - `cover` - set position
 - `fan` - set speed (assumes first setting is `off`)
 - `input_number`

--- a/slider-entity-row.js
+++ b/slider-entity-row.js
@@ -132,7 +132,7 @@ class SliderEntityRow extends Polymer.Element {
         },
         string: (stateObj, l18n) => {
           if (stateObj.attributes.is_volume_muted) return '-';
-          return `${this.controller.get(stateObj)} %`;
+          return !!stateObj.attributes.volume_level ? `${this.controller.get(stateObj)} %` : l18n['state.default.off'];
         },
         min: () => 0,
         max: () => 100,

--- a/slider-entity-row.js
+++ b/slider-entity-row.js
@@ -132,7 +132,7 @@ class SliderEntityRow extends Polymer.Element {
         },
         string: (stateObj, l18n) => {
           if (stateObj.attributes.is_volume_muted) return '-';
-          return !!stateObj.attributes.volume_level ? `${this.controller.get(stateObj)} %` : l18n['state.default.off'];
+          return !!stateObj.attributes.volume_level ? `${this.controller.get(stateObj)} %` : l18n['state.media_player.off'];
         },
         min: () => 0,
         max: () => 100,

--- a/slider-entity-row.js
+++ b/slider-entity-row.js
@@ -152,7 +152,7 @@ class SliderEntityRow extends Polymer.Element {
           toggle: () => true,
         },
         string: (stateObj, l18n) => {
-          if (stateObj.attributes.operation_mode === 'off') return l18n['state.default.off'];
+          if (stateObj.attributes.operation_mode === 'off') return l18n['state.climate.off'];
           return `${this.controller.get(stateObj)} ${this._hass.config.unit_system.temperature}`;
         },
         min: (stateObj) => stateObj.attributes.min_temp,

--- a/slider-entity-row.js
+++ b/slider-entity-row.js
@@ -139,6 +139,27 @@ class SliderEntityRow extends Polymer.Element {
         step: () => 5,
       },
 
+      climate: {
+        set: (stateObj, value) => {
+          this._hass.callService('climate', 'set_temperature', {
+            entity_id: stateObj.entity_id,
+            temperature: value
+          });
+        },
+        get: (stateObj) => stateObj.attributes.temperature,
+        supported: {
+          slider: () => true,
+          toggle: () => true,
+        },
+        string: (stateObj, l18n) => {
+          if (stateObj.attributes.operation_mode === 'off') return l18n['state.default.off'];
+          return `${this.controller.get(stateObj)} ${this._hass.config.unit_system.temperature}`;
+        },
+        min: (stateObj) => stateObj.attributes.min_temp,
+        max: (stateObj) => stateObj.attributes.max_temp,
+        step: () => 1,
+      },
+
       cover: {
         set: (stateObj, value) => {
           if (value)


### PR DESCRIPTION
Simple support for the climate domain.

Slider sets (target) temperature of the climate entity. State shows current targeted temperature. Toggle turns climate thermostat on/off.

Also fixed issue where media_player is showing NaN % (ref [issue 36](https://github.com/thomasloven/lovelace-slider-entity-row/issues/36)).