### PR TITLE
Fix slider bar overflow

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -107,6 +107,7 @@ class SliderEntityRow extends LitElement {
         display: flex;
         align-items: center;
         height: 40px;
+        flex: 1 0 200px;
       }
       .state {
         min-width: 45px;
@@ -115,6 +116,10 @@ class SliderEntityRow extends LitElement {
       }
       ha-entity-toggle {
         margin-left: 8px;
+      }
+      ha-slider {
+        width: auto;
+        flex-grow: 1;
       }
       ha-slider.full {
         width: 100%;


### PR DESCRIPTION
- Home Assistant version 0.107.7

slider bar will overflow on mobile
# Example
```yaml
type: entities
title: Options
entities:
  - type: custom:slider-entity-row
    entity: light.bed_light
    name: Default
  - type: custom:slider-entity-row
    entity: light.bed_light
    name: toggle
    toggle: true
  - type: custom:slider-entity-row
    entity: light.bed_light
    name: hide_state
    hide_state: true
  - type: custom:slider-entity-row
    entity: light.ceiling_lights
    name: hide_when_off
    hide_when_off: true
  - type: custom:slider-entity-row
    entity: light.ceiling_lights
    name: hide_when_off + toggle
    hide_when_off: true
    toggle: true
  - type: section
    label: full_row
  - type: custom:slider-entity-row
    entity: light.bed_light
    name: hide_state
    full_row: true
```
## Mobile
|befroe|after|
|:-:|:-:|
|![圖片 004](https://user-images.githubusercontent.com/17023091/77826690-dfd53800-714b-11ea-98a1-a3c1fecc6af5.png)|![圖片 005](https://user-images.githubusercontent.com/17023091/77826693-e2d02880-714b-11ea-927b-aa64f2b0c2ed.png)|

## Desktop
|befroe|after|
|:-:|:-:|
|![圖片 002](https://user-images.githubusercontent.com/17023091/77826651-abfa1280-714b-11ea-8aa2-79c79625c8c6.png)|![圖片 003](https://user-images.githubusercontent.com/17023091/77826655-b0bec680-714b-11ea-958a-d919632091e2.png)|