### PR TITLE
Fix #117. Corrected ha-entity-toggle alignment

### DIFF
--- a/slider-entity-row.js
+++ b/slider-entity-row.js
@@ -50,6 +50,7 @@
         margin-left: 5px;
       }
       ha-entity-toggle {
+        min-width: auto;
         margin-left: 8px;
       }
       ha-slider {

--- a/src/main.js
+++ b/src/main.js
@@ -128,6 +128,7 @@ class SliderEntityRow extends LitElement {
         margin-left: 5px;
       }
       ha-entity-toggle {
+        min-width: auto;
         margin-left: 8px;
       }
       ha-slider {


### PR DESCRIPTION
This MR will make sure that the toggle buttons of the slider entity row will be positioned on exactly the same place as the default entity row buttons.

It's tested on all major desktop and mobile browsers. 
