### PR TITLE
Add options for brightness value #114

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Currenly supported entity domains:
 - `max: <value>` - Set maximum value of slider
 - `step: <value>` - Set step size of slider
 - `attribute: <value>` - Select which attribute the slider should control
+- `brightness_percent: true` - Only for light domain. When `true` (the default) shows brightness as a percent in a range from 0% to 100%. When `false` shows brightness in the range 0 to 255.
 
 ```yaml
 type: entities

--- a/src/light-controller.js
+++ b/src/light-controller.js
@@ -14,7 +14,11 @@ export class LightController extends Controller {
       case "white_value":
         return Math.ceil(this.stateObj.attributes.white_value);
       case "brightness":
-        return Math.ceil(this.stateObj.attributes.brightness*100.0/255);
+        if (this._config.brightness_percent === undefined || (this._config.brightness_percent !== undefined && this._config.brightness_percent)) {
+          return Math.ceil(this.stateObj.attributes.brightness*100.0/255);
+        } else {
+          return this.stateObj.attributes.brightness;
+        }
       case "red":
         return this.stateObj.attributes.rgb_color ? Math.ceil(this.stateObj.attributes.rgb_color[0]) : 0;
       case "green":
@@ -35,6 +39,7 @@ export class LightController extends Controller {
   }
 
   get _step() {
+    if (this._config.brightness_percent !== undefined && !this._config.brightness_percent) return 1;
     switch (this.attribute) {
       case "effect":
         return 1;
@@ -64,6 +69,12 @@ export class LightController extends Controller {
         return 360;
       case "effect":
         return this.stateObj ? this.stateObj.attributes.effect_list ? this.stateObj.attributes.effect_list.length - 1 : 0 : 0;
+      case "brightness":
+        if (this._config.brightness_percent === undefined || (this._config.brightness_percent !== undefined && this._config.brightness_percent)) {
+          return 100;
+        } else {
+          return 255;
+        }
       default:
         return 100;
     }
@@ -76,7 +87,9 @@ export class LightController extends Controller {
     let _value;
     switch (attr) {
       case "brightness":
-        value = Math.ceil(value/100.0*255);
+        if (this._config.brightness_percent === undefined || (this._config.brightness_percent !== undefined && this._config.brightness_percent)) {
+          value = Math.ceil(value/100.0*255);
+        }
         if (!value) on = false;
         break;
       case "red":
@@ -122,6 +135,7 @@ export class LightController extends Controller {
       case "color_temp":
         return `${this.value}`;
       case "brightness":
+        return this._config.brightness_percent === undefined || (this._config.brightness_percent !== undefined && this._config.brightness_percent) ? `${this.value} %` : `${this.value}`;
       case "saturation":
         return `${this.value} %`;
       case "hue":


### PR DESCRIPTION
I want to be able to setup this card to work exactly as the native control for brightness in Home Assistant. This card shows brightness as a percent, but HA is showing brightness as value from 1 to 255:

![Screenshot 2020-05-02 at 15 21 28](https://user-images.githubusercontent.com/47263/80864047-af237980-8c88-11ea-8a5c-57041045b86b.png)

So I've  prepared this code. With this code the card behaviour stays the same, but there is a new option. When it is specified and it is `true` the the card is showing pure numbers instead of percent.

Here is an example usage (the first row is the default usage of this card, the second is the usage with the new option):

![Screenshot 2020-05-02 at 15 25 55](https://user-images.githubusercontent.com/47263/80864119-3f61be80-8c89-11ea-8456-32489f6d9991.png)

```
title: Home
views:
  - badges: []
    cards:
      - entities:
         
          - type: 'custom:slider-entity-row'
            entity: light.lamp
            
          - type: 'custom:slider-entity-row'
            entity: light.lamp
            brightness_percent: false
       
        show_header_toggle: false
        type: entities
```

I'm not very happy with the code that I've written, but it working.