### PR TITLE
(feat) Allow slider inversion via yaml config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Currenly supported entity domains:
 - `max: <value>` - Set maximum value of slider
 - `step: <value>` - Set step size of slider
 - `attribute: <value>` - Select which attribute the slider should control
+- `inverted: true` - Inverts slider percentage
 
 ```yaml
 type: entities

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slider-entity-row",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "slider-entity-row =================",
   "scripts": {
     "build": "webpack",

--- a/slider-entity-row.js
+++ b/slider-entity-row.js
@@ -3,10 +3,10 @@
         .min=${t.min}
         .max=${t.max}
         .step=${t.step}
-        .value=${t.value}
+        .value=${this._config.inverted?100-t.value:t.value}
         .dir=${e}
         pin
-        @change=${e=>t.value=this.shadowRoot.querySelector("ha-slider").value}
+        @change=${e=>{let s=this._config.inverted?100-this.shadowRoot.querySelector("ha-slider").value:this.shadowRoot.querySelector("ha-slider").value;t.value=s}}
         class=${this._config.full_row?"full":""}
         ignore-bar-touch
       ></ha-slider>
@@ -27,7 +27,7 @@
 
             ${this._config.toggle?t.hasToggle?i:"":(this._config.hide_state||this.hide_state)&&!1!==this._config.hide_state?"":a`
                     <span class="state">
-                      ${t.string}
+                      ${this._config.inverted?(()=>{let e=/[0-9]{2}/.exec(t.string)||[];return e.length?t.string.replace(e[0],100-t.value):t.string})():t.string}
                     </span>
                   `}
           `}

--- a/src/main.js
+++ b/src/main.js
@@ -58,10 +58,15 @@ class SliderEntityRow extends LitElement {
         .min=${c.min}
         .max=${c.max}
         .step=${c.step}
-        .value=${c.value}
+        .value=${this._config.inverted ? 100 - c.value : c.value}
         .dir=${dir}
         pin
-        @change=${(ev) => c.value = this.shadowRoot.querySelector("ha-slider").value}
+        @change=${(ev) => {
+          let target = this._config.inverted ?
+            100 - this.shadowRoot.querySelector("ha-slider").value :
+            this.shadowRoot.querySelector("ha-slider").value;
+          c.value = target
+        }}
         class=${this._config.full_row ? "full" : ""}
         ignore-bar-touch
       ></ha-slider>
@@ -96,7 +101,16 @@ class SliderEntityRow extends LitElement {
                 ? ''
                 : html`
                     <span class="state">
-                      ${c.string}
+                      ${this._config.inverted ?
+                        (() => {
+                          let matches = /[0-9]{2}/.exec(c.string) || [];
+                          if (!matches.length) {
+                            return c.string;
+                          }
+                          return c.string.replace(matches[0], 100 - c.value);
+                        })() :
+                        c.string
+                      }
                     </span>
                   `
             }


### PR DESCRIPTION
Useful at least for tradfri covers. They report 0% when fully extended
and 100% when fully withdrawn. Makes sense from a closed/open perspective,
but not so much when represented as a slider.