### PR TITLE
Show toggle switches for unavailable entities. Fixes #130

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -88,11 +88,13 @@ class SliderEntityRow extends LitElement {
     const content = html`
     <div class="wrapper" @click=${(ev) => ev.stopPropagation()}>
       ${(c.stateObj.state === "unavailable")
-        ? html`
-            <span class="state">
-            ${this.hass.localize("state.default.unavailable")}
-            </span>
-        `
+        ? this._config.toggle && c.hasToggle 
+          ? toggle 
+          : html`
+              <span class="state">
+              ${this.hass.localize("state.default.unavailable")}
+              </span>
+            `
         : html`
             ${((this._config.hide_when_off && c.isOff)
               || !c.hasSlider)


### PR DESCRIPTION
This fixes #130 by showing a toggle switch when `toggle` is enabled even if the entity is unavailable.