### PR TITLE
Make --paper-slider-secondary-color: transparent to prevent it showing when slider is set to a negative number

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -133,6 +133,7 @@ class SliderEntityRow extends LitElement {
       ha-slider {
         width: 100%;
         min-width: 100px;
+        --paper-slider-secondary-color: transparent;
       }
       ha-slider:not(.full) {
         max-width: 200px;


### PR DESCRIPTION
The world of web components and custom css properties are new to me so no idea if this is an acceptable fix  :smile:

I can't see a way to turn off using the secondary progress feature in paper-slider/progress so went with styling it.

Fix #203