### PR TITLE
Additional space for Value needed if step < 1

### DIFF
--- a/slider-entity-row.js
+++ b/slider-entity-row.js
@@ -41,7 +41,7 @@ function t(t,e,s,i){var r,n=arguments.length,a=n<3?e:null===i?i=Object.getOwnPro
         height: 40px;
       }
       .state {
-        min-width: 45px;
+        min-width: 55px;
         text-align: end;
         margin-left: 5px;
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -122,7 +122,7 @@ class SliderEntityRow extends LitElement {
         height: 40px;
       }
       .state {
-        min-width: 45px;
+        min-width: 55px;
         text-align: end;
         margin-left: 5px;
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -122,9 +122,8 @@ class SliderEntityRow extends LitElement {
         height: 40px;
       }
       .state {
-        min-width: 55px;
+        min-width: 45px;
         text-align: end;
-        margin-left: 5px;
       }
       ha-entity-toggle {
         min-width: auto;


### PR DESCRIPTION
My Home Assistant version: core-2021.10.5

To avoid having Value and Unit is different rows, additional space for them is needed in case:

full_row: true
step: 0.1

![image](https://user-images.githubusercontent.com/6759133/137641512-3db81f09-bad4-410d-9c42-b2b69c29d70e.png)

After the change:
![image](https://user-images.githubusercontent.com/6759133/137641677-b152ba77-0ecf-46e8-a466-a8181153818a.png)


