### PR TITLE
Option to set unit for light entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Available options:
 | `full_row`      | `true`/`false` | Hide the icon and name and stretch slider to full width                                                                                   | `false`  |
 | `attribute`     | (see below)    | Which attribute the slider should control                                                                                                 |          |
 | `dir`           | `ltr`/`rtl`    | Use this to override your languages Right-To-Left or Left-To-Right setting                                                                | language |
+| `state_unit`    | string         | Unit to show for "unitless" values (brightness, color_temp, currently only for light components)                                                            | none |
 
 Most general Entities row options like `name`, `icon` and `tap_action` et.al. are also supported.
 

--- a/src/controllers/controller.ts
+++ b/src/controllers/controller.ts
@@ -12,6 +12,7 @@ export interface ControllerConfig {
   attribute?: string;
   grow?: boolean;
   dir?: string;
+  state_unit?: string;
 }
 
 export abstract class Controller {

--- a/src/controllers/light-controller.ts
+++ b/src/controllers/light-controller.ts
@@ -15,6 +15,10 @@ export class LightController extends Controller {
     return this._config.attribute || "brightness_pct";
   }
 
+  get state_unit() {
+    return this._config.state_unit || undefined;
+  }
+ 
   get _rgbww() {
     const attr = this.stateObj.attributes;
     switch (attr.color_mode) {
@@ -193,6 +197,9 @@ export class LightController extends Controller {
     switch (this.attribute) {
       case "color_temp":
       case "brightness":
+        if (this.state_unit) {
+          return `${this.value} ${this.state_unit}`;
+        }
         return `${this.value}`;
       case "brightness_pct":
       case "saturation":


### PR DESCRIPTION
Hello,

I (mis-)use the light component for my garden water. The value here is not absolute brightness, it's "minutes" instead. This PR allows to set a unit for the state for unit-less values. It's for light only but could easily extended for other entities if someone requires this.