### PR TITLE
support select domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ entities:
 - `cover` - set position
 - `fan` - set speed (assumes first setting is `off`)
 - `input_number` - set value (only if `mode: slider`)
-- `input_select` - select option
+- `select`, `input_select` - select option
 - `number` - set value
 - `timer` - set number of seconds remaining
 

--- a/src/controllers/controller.ts
+++ b/src/controllers/controller.ts
@@ -20,6 +20,7 @@ export abstract class Controller {
   _config: ControllerConfig;
   _hass: any;
   stateObj: any;
+  _domain: string;
 
   abstract _value?: number;
   abstract _min?: number;
@@ -28,8 +29,9 @@ export abstract class Controller {
 
   static allowed_attributes = [];
 
-  constructor(config: ControllerConfig, parent) {
+  constructor(config: ControllerConfig, parent: any, domain: string) {
     this._config = config;
+    this._domain = domain;
   }
 
   set hass(hass: any) {

--- a/src/controllers/get-controller.ts
+++ b/src/controllers/get-controller.ts
@@ -18,6 +18,7 @@ export const controllers = {
   cover: CoverController,
   fan: FanController,
   input_number: InputNumberController,
+  select: InputSelectController,
   input_select: InputSelectController,
   number: NumberController,
   humidifier: HumidifierController,

--- a/src/controllers/input-select-controller.ts
+++ b/src/controllers/input-select-controller.ts
@@ -9,7 +9,7 @@ export class InputSelectController extends Controller {
 
   set _value(value) {
     if (value in this.stateObj.attributes.options)
-      this._hass.callService("input_select", "select_option", {
+      this._hass.callService(this._domain, "select_option", {
         entity_id: this.stateObj.entity_id,
         option: this.stateObj.attributes.options[value],
       });

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@ class SliderEntityRow extends LitElement {
     const domain = config.entity.split(".")[0];
     const ctrlClass = getController(domain);
     if (!ctrlClass) throw new Error(`Unsupported entity type: ${domain}`);
-    this.ctrl = new ctrlClass(config, this);
+    this.ctrl = new ctrlClass(config, this, domain);
   }
 
   static getConfigElement() {


### PR DESCRIPTION
Some integrations like localtuya provide only select as an entity for options.
`select `and `input_select ` are the same in terms of available actions, so i've just reused existing controller passing domain to it.